### PR TITLE
Issues #347 - Issue with "keepMirroringOnWrite = YES" - a black scree…

### DIFF
--- a/Library/Sources/SCRecorder.m
+++ b/Library/Sources/SCRecorder.m
@@ -92,7 +92,8 @@ static char* SCRecorderPhotoOptionsContext = "PhotoOptionsContext";
         [_audioConfiguration addObserver:self forKeyPath:@"enabled" options:NSKeyValueObservingOptionNew context:SCRecorderAudioEnabledContext];
         [_photoConfiguration addObserver:self forKeyPath:@"options" options:NSKeyValueObservingOptionNew context:SCRecorderPhotoOptionsContext];
         
-        _context = [SCContext new].CIContext;
+        _context = [SCContext contextWithType:[SCContext suggestedContextType]
+                                      options:nil].CIContext;
     }
     
     return self;


### PR DESCRIPTION
…n in video

Analysis: [SCContext new] does not initialize CIContext and returns nil. Image can't be mirrored using nil CIContext and returns just black blank image frame in video.
Solution: Init SCContext with suggested type in general SCRecorder initialization